### PR TITLE
Simplify Pull Request workflow

### DIFF
--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test using iPhone 13 running iOS 15.7
+    name: Build and Test using iPhone 13 Simulator running iOS 15.7
     runs-on: macos-latest
 
     steps:
@@ -15,18 +15,18 @@ jobs:
       - name: Build
         env:
           scheme: Spoof
-          platform: ${{ 'iOS' }}
+          platform: ${{ 'iOS Simulator' }}
         run: |
-          destination="platform=iOS,name=iPhone 13,OS=15.7"
+          destination="platform=iOS Simulator,name=iPhone 13,OS=15.7"
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
           xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "$destination"
       - name: Test
         env:
           scheme: Spoof
-          platform: ${{ 'iOS' }}
+          platform: ${{ 'iOS Simulator' }}
         run: |
-          destination="platform=iOS,name=iPhone 13,OS=15.7"
+          destination="platform=iOS Simulator,name=iPhone 13,OS=15.7"
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
           xcodebuild test-without-building -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "$destination"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -25,4 +25,4 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           destination="platform=iOS Simulator,name=iPhone 14"
-          xcodebuild test-without-building -scheme "$scheme" -project "Spoof.xcodeproj" -destination "$destination"
+          xcodebuild test-without-building -scheme "$scheme" -project "Spoof.xcodeproj" -destination "$destination" -only-testing:Spoof/SpoofUITests/SpoofUITestsLaunchTests/testLaunch

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -12,15 +12,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Default Scheme
-        run: |
-          scheme_list=$(xcodebuild -list -json | tr -d "\n")
-          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
-          echo $default | cat >default
-          echo Using default scheme: $default
       - name: Build
         env:
-          scheme: ${{ 'default' }}
+          scheme: Spoof
           platform: ${{ 'iOS Simulator' }}
         run: |
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
@@ -31,7 +25,7 @@ jobs:
           xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
       - name: Test
         env:
-          scheme: ${{ 'default' }}
+          scheme: Spoof
           platform: ${{ 'iOS Simulator' }}
         run: |
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -18,15 +18,11 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           destination="platform=iOS Simulator,name=iPhone 14"
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "$destination"
+          xcodebuild build-for-testing -scheme "$scheme" -project "Spoof.xcodeproj" -destination "$destination"
       - name: Test
         env:
           scheme: Spoof
           platform: ${{ 'iOS Simulator' }}
         run: |
           destination="platform=iOS Simulator,name=iPhone 14"
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild test-without-building -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "$destination"
+          xcodebuild test-without-building -scheme "$scheme" -project "Spoof.xcodeproj" -destination "$destination"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test using iPhone 14 Simulator
+    name: Build and Test
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -25,4 +25,4 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           destination="platform=iOS Simulator,name=iPhone 14"
-          xcodebuild test-without-building -scheme "$scheme" -project "Spoof.xcodeproj" -destination "$destination" -only-testing:Spoof/SpoofUITests/SpoofUITestsLaunchTests/testLaunch
+          xcodebuild test-without-building -scheme "$scheme" -project "Spoof.xcodeproj" -destination "$destination" -only-testing:SpoofUITests/SpoofUITestsLaunchTests/testLaunch

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -21,7 +21,7 @@ jobs:
           xcodebuild build-for-testing -scheme "$scheme" -project "Spoof.xcodeproj" -destination "$destination"
       - name: Test
         env:
-          scheme: Spoof
+          scheme: SpoofUITests
           platform: ${{ 'iOS Simulator' }}
         run: |
           destination="platform=iOS Simulator,name=iPhone 14"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -21,7 +21,7 @@ jobs:
           xcodebuild build-for-testing -scheme "$scheme" -project "Spoof.xcodeproj" -destination "$destination"
       - name: Test
         env:
-          scheme: SpoofUITests
+          scheme: Spoof
           platform: ${{ 'iOS Simulator' }}
         run: |
           destination="platform=iOS Simulator,name=iPhone 14"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test default scheme using any available iPhone simulator
+    name: Build and Test using any available iPhone simulator
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -17,7 +17,7 @@ jobs:
           scheme: Spoof
           platform: ${{ 'iOS Simulator' }}
         run: |
-          destination="platform=iOS Simulator,name=iPhone 13,OS=15.7"
+          destination="platform=iOS Simulator,name=iPhone 14"
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
           xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "$destination"
@@ -26,7 +26,7 @@ jobs:
           scheme: Spoof
           platform: ${{ 'iOS Simulator' }}
         run: |
-          destination="platform=iOS Simulator,name=iPhone 13,OS=15.7"
+          destination="platform=iOS Simulator,name=iPhone 14"
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
           xcodebuild test-without-building -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "$destination"

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test using iPhone 13 Simulator running iOS 15.7
+    name: Build and Test using iPhone 14 Simulator
     runs-on: macos-latest
 
     steps:

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   build:
-    name: Build and Test using any available iPhone simulator
+    name: Build and Test using iPhone 13 running iOS 15.7
     runs-on: macos-latest
 
     steps:
@@ -15,22 +15,18 @@ jobs:
       - name: Build
         env:
           scheme: Spoof
-          platform: ${{ 'iOS Simulator' }}
+          platform: ${{ 'iOS' }}
         run: |
-          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-          if [ $scheme = default ]; then scheme=$(cat default); fi
+          destination="platform=iOS,name=iPhone 13,OS=15.7"
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "$destination"
       - name: Test
         env:
           scheme: Spoof
-          platform: ${{ 'iOS Simulator' }}
+          platform: ${{ 'iOS' }}
         run: |
-          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}' | sed -e "s/ Simulator$//"`
-          if [ $scheme = default ]; then scheme=$(cat default); fi
+          destination="platform=iOS,name=iPhone 13,OS=15.7"
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild test-without-building -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+          xcodebuild test-without-building -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "$destination"


### PR DESCRIPTION
1. Build a specific scheme instead of running commands to determine which scheme should be built
2. Use a specific simulator (iPhone 14) instead of using "any available iPhone simulator"
3. Define xcodebuild arguments instead of running commands to determine what those arguments should be
4. Only run one specific test instead of running all the tests for the scheme